### PR TITLE
14 types refactor with derivestore

### DIFF
--- a/src/ensurers/renderEnsurer.ts
+++ b/src/ensurers/renderEnsurer.ts
@@ -9,6 +9,7 @@ export {
   type ResultCleanup,
   type Compute,
   type PlugCallback,
+  type DeriveStore,
   useObj as useBadPractice,
   useState,
   useReplaceableState,
@@ -717,12 +718,10 @@ function useStore<
   ActionType,
   InitialType,
 >(
-  derive: (
-    (
-      oldStore: StoreType,
-      action: ActionType,
-    ) => StoreType
-  ),
+  derive: DeriveStore<
+    StoreType,
+    ActionType
+  >,
   initialValue: InitialType,
   getInitialStore: (
     initialValue: InitialType,
@@ -741,12 +740,10 @@ function useStore<
   ActionType,
   InitialType,
 >(
-  derive: (
-    (
-      oldStore: StoreType,
-      action: ActionType,
-    ) => StoreType
-  ),
+  derive: DeriveStore<
+    StoreType,
+    ActionType
+  >,
   initialStore?: StoreType,
 ): readonly [
   store: StoreType,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ export {
   type ResultCleanup,
   type Compute,
   type PlugCallback,
+  type DeriveStore,
   useBadPractice,
   useState,
   useReplaceableState,


### PR DESCRIPTION
replaced some duplicated arg types with `DeriveStore`;

exported `DeriveStore` type for typing variables that will be used as arguments for `useStore`;